### PR TITLE
Increased depth of xrx data pipe to improve throughput

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/MVDR.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/MVDR.hpp
@@ -194,8 +194,10 @@ MVDREventArray SubmitMVDRKernels(
                      TrainingDataPipe, TrainingDataPipeOut>;
 
   // Xrx processing data pipe and duplicator (after demux from input data)
+  // Must provide sufficient depth to not produce backpressure while training
+  // data is processed (4 full matrices is adequate)                     
   constexpr int kXrxDataPipeMinDepth =
-      kTrainingMatrixSize / k_num_complex_per_xrx_read;
+      (kTrainingMatrixSize / k_num_complex_per_xrx_read) * 4;
   using XrxDataPipe = sycl::INTEL::pipe<XrxDataPipeID<k_instance_num>,
                                         XrxPipeType, kXrxDataPipeMinDepth>;
 


### PR DESCRIPTION
# Description

Throughput was being limited because the InputDemux would fill up the XrxDataPipe, then be unable to accept any more data.  With a deeper XrxDataPipe, InputDemux no longer stalls and the limiting factor on throughput (for the large array) is now the QRD kernel as expected.
