### PR TITLE
Update FPGA gzip design Cmake file to use different method to build low latency / high bandwidth versions.

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/README.md
@@ -100,25 +100,27 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
    ```
    cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm
    ```
+   To compile for the Low Latency version of the design use the command
+
+   ```
+   cmake .. -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm
+   ```
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 
    * Compile for emulation (fast compile time, targets emulated FPGA device):
       ```
       make fpga_emu
       ```
-    > Note: for the Low Latency variant, use `make fpga_emu_ll`. Only supported on Stratix® 10 SX.
 
    * Generate the optimization report:
      ```
      make report
      ```
-    > Note: for the Low Latency variant, use `make report_ll`. Only supported on Stratix® 10 SX.
 
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
      ```
-    > Note: for the Low Latency variant, use `make fpga_ll`. Only supported on Stratix® 10 SX.
 3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/gzip.fpga.tar.gz" download>here</a>.
 
 ### On a Windows* System
@@ -137,6 +139,11 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
    ```
    cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm
    ```
+   To compile for the Low Latency version of the design use the command:
+
+   ```
+   cmake -G "Nmake Makefiles" .. -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm
+   ```
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 
@@ -144,12 +151,10 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
      ```
      nmake fpga_emu
      ```
-    > Note: for the Low Latency variant, use `nmake fpga_emu_ll`. Only supported on Stratix® 10 SX.
    * Generate the optimization report:
      ```
      nmake report
      ```
-    > Note: for the Low Latency variant, use `nmake report_ll`. Only supported on Stratix® 10 SX.
    * An FPGA hardware target is not provided on Windows*.
 
 *Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.
@@ -166,13 +171,11 @@ You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Vi
      ./gzip.fpga_emu <input_file> [-o=<output_file>]     (Linux)
      gzip.fpga_emu.exe <input_file> [-o=<output_file>]   (Windows)
      ```
-    > Note: for the Low Latency variant use `gzip_ll.fpga_emu`. Only supported on Stratix® 10 SX.
 2. Run the sample on the FPGA device:
      ```
      aocl initialize acl0 pac_s10_usm
      ./gzip.fpga <input_file> [-o=<output_file>]         (Linux)
      ```
-     > Note: for the Low Latency variant use `gzip_ll.fpga`. Only supported on Stratix® 10 SX.
  ### Application Parameters
 
 | Argument | Description
@@ -215,7 +218,7 @@ PASSED
 ---    |---
 `-Xshardware` | Target FPGA hardware (as opposed to FPGA emulator)
 `-Xsparallel=2` | Uses two cores when compiling the bitstream through Quartus®
-`-Xsseed=8` | Uses seed 8 (seed 33 for Low latency Variant) during Quartus®, yields slightly higher fmax
+`-Xsseed=<seed_num>` | Uses a particular seed while running Quartus®, selected to yield the best Fmax for this desgin
 `-Xsnum-reorder=6` | On Intel Stratix® 10 SX only, specify a wider data path for read data from global memory
 `-Xsopt-arg="-nocaching"` | Specifies that cached LSUs should not be used.
 `-DNUM_ENGINES=<1|2>` | Specifies that 1 GZIP engine should be compiled when targeting Intel Arria® 10 GX and two engines when targeting Intel Stratix® 10 SX

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -1,20 +1,22 @@
 set(TARGET_NAME gzip)
 
-# High bandwidth variant
-set(SOURCE_FILE gzip.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+
+if(LOW_LATENCY)
+    # Compile the low latency version of the design
+    message(STATUS "Compiling the Low Latency variant of the design")
+    set(SOURCE_FILE gzip_ll.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+    set(DEVICE_SOURCE_FILE gzipkernel_ll.cpp)
+    set(DEVICE_HEADER_FILE gzipkernel_ll.hpp)
+else()
+    # Compile the high bandwidth version of the design
+    message(STATUS "Compiling the High Bandwidth variation of the design")
+    set(SOURCE_FILE gzip.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+    set(DEVICE_SOURCE_FILE gzipkernel.cpp)
+    set(DEVICE_HEADER_FILE gzipkernel.hpp)
+endif()
+
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
-set(DEVICE_SOURCE_FILE gzipkernel.cpp)
-set(DEVICE_HEADER_FILE gzipkernel.hpp)
-set(HIGH_BW_SEED "-Xsseed=8")
-
-# Low latency variant
-set(SOURCE_FILE_LL gzip_ll.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
-set(EMULATOR_TARGET_LL ${TARGET_NAME}_ll.fpga_emu)
-set(FPGA_TARGET_LL ${TARGET_NAME}_ll.fpga)
-set(DEVICE_SOURCE_FILE_LL gzipkernel_ll.cpp)
-set(DEVICE_HEADER_FILE_LL gzipkernel_ll.hpp)
-set(LL_SEED "-Xsseed=1")
 
 # FPGA board selection
 if(NOT DEFINED FPGA_BOARD)
@@ -35,41 +37,53 @@ endif()
 if(FPGA_BOARD MATCHES ".*a10.*")
     # A10 parameters
     set(NUM_ENGINES 1)
-    set(LL_SEED "-Xsseed=4")
-    set(HIGH_BW_SEED "-Xsseed=4")
-    set(NUM_REORDER "")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=4")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=4")
+        set(NUM_REORDER "")
+    endif()
 elseif(FPGA_BOARD MATCHES ".*s10.*")
     # S10 parameters
     set(NUM_ENGINES 2)
-    set(LL_SEED "-Xsseed=19")
-    set(HIGH_BW_SEED "-Xsseed=18")
-    set(NUM_REORDER "-Xsnum-reorder=6")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=19")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=18")
+        # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
+        # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
+        set(NUM_REORDER "-Xsnum-reorder=6")
+    endif()
 elseif(FPGA_BOARD MATCHES ".*agilex.*")
     # Agilex™
     set(NUM_ENGINES 2)
-    set(LL_SEED "-Xsseed=1")
-    set(HIGH_BW_SEED "-Xsseed=8")
-    # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
-    # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
-    set(NUM_REORDER "-Xsnum-reorder=6")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=1")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=8")
+        # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
+        # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
+        set(NUM_REORDER "-Xsnum-reorder=6")
+    endif()
 else()
-    message(FATAL_ERROR "Unknown board!")
+    set(NUM_ENGINES 1)
+    set(SEED "-Xsseed=1")
+    set(NUM_REORDER "")
 endif()
 
-# Enable low-latency variant
 # Presence of USM host allocations (and whether to turn on enable the low-latency target) is detected automatically by
 # looking at the name of the BSP, or manually by the user when running CMake.
 # E.g., cmake .. -DUSER_ENABLE_USM=1
 if(FPGA_BOARD MATCHES ".*usm.*" OR DEFINED USER_ENABLE_USM)
     set(USM_ENABLED 1)
-    set(NUM_REORDER_LL "")
 endif()
 
 message(STATUS "NUM_ENGINES=${NUM_ENGINES}")
-message(STATUS "LL_SEED=${LL_SEED}")
-message(STATUS "HIGH_BW_SEED=${HIGH_BW_SEED}")
+message(STATUS "SEED=${SEED}")
 message(STATUS "NUM_REORDER=${NUM_REORDER}")
-message(STATUS "NUM_REORDER_LL=${NUM_REORDER_LL}")
 
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
@@ -81,11 +95,6 @@ set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DNUM_ENGINES=${NUM_EN
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsparallel=2 -Xsopt-arg=\"-nocaching\" -Xsboard=${FPGA_BOARD} -DNUM_ENGINES=${NUM_ENGINES} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#                           High Bandwidth Variant                             #
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
 ###############################################################################
 ### FPGA Emulator
 ###############################################################################
@@ -102,7 +111,7 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${HIGH_BW_SEED} -fsycl-link=early")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${SEED} -fsycl-link=early")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
 ###############################################################################
@@ -111,52 +120,9 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${HIGH_BW_SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
 # See DPC++FPGA/GettingStarted/fast_recompile for details.
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
 
 
 
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#                            Low Latency Variant                               #
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-if (${USM_ENABLED})
-###############################################################################
-### FPGA Emulator
-###############################################################################
-add_executable(${EMULATOR_TARGET_LL} ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-set_target_properties(${EMULATOR_TARGET_LL} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
-set_target_properties(${EMULATOR_TARGET_LL} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
-add_custom_target(fpga_emu_ll DEPENDS ${EMULATOR_TARGET_LL})
-
-###############################################################################
-### Generate Report
-###############################################################################
-set(FPGA_EARLY_IMAGE_LL ${TARGET_NAME}_ll_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
-add_executable(${FPGA_EARLY_IMAGE_LL} ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-add_custom_target(report_ll DEPENDS ${FPGA_EARLY_IMAGE_LL})
-set_target_properties(${FPGA_EARLY_IMAGE_LL} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_EARLY_IMAGE_LL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER_LL} ${LL_SEED} -fsycl-link=early")
-# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
-
-###############################################################################
-### FPGA Hardware
-###############################################################################
-add_executable(${FPGA_TARGET_LL} EXCLUDE_FROM_ALL ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-add_custom_target(fpga_ll DEPENDS ${FPGA_TARGET_LL})
-set_target_properties(${FPGA_TARGET_LL} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_TARGET_LL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER_LL} ${LL_SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_LL}")
-# The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
-endif()
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#


### PR DESCRIPTION
…nt based on a flag passed in to CMAKE, instead of making separate Makefile targets for the Low Latency version.

Signed-off-by: mtucker <mike.d.b.tucker@intel.com>

# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**

**_Delete this line and all above it if this PR is for a new code sample_**
# Adding a New Sample(s)

## Description

Please include a description of the sample

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>
- [ ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager: @JoeOster

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see @JoeOster for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Joe Oster(@JoeOster)
- [ ] Tested using Dev Cloud when applicable
